### PR TITLE
fix two typos

### DIFF
--- a/source/polylib_mod/compress_parms.c
+++ b/source/polylib_mod/compress_parms.c
@@ -90,7 +90,7 @@ Matrix * int_ker(Matrix * M) {
     show_matrix(H2);
     show_matrix(U); 
   }
-  H->NbRows==M->NbRows;
+  H->NbRows=M->NbRows;
   Matrix_Free(H);
   /* the Integer Kernel is made of the last n-rk columns of U */
   Matrix_subMatrix(U, 0, rk, U->NbRows, U->NbColumns, &K);

--- a/source/polylib_mod/polylib/homogenization.h
+++ b/source/polylib_mod/polylib/homogenization.h
@@ -17,7 +17,7 @@
 
 /** homogenization.h -- Bavo Nootaert **/
 #ifndef HOMOGENIZATION_H
-#define HOMOGENIZATTON_H
+#define HOMOGENIZATION_H
 
 #include <polylib/polylib.h>
 


### PR DESCRIPTION
The clang compiler gave warnings about these typos.