### PR TITLE
Fix C++11 literal-suffix warning by adding spaces around format macro

### DIFF
--- a/source/polylib_mod/matrix.c
+++ b/source/polylib_mod/matrix.c
@@ -150,7 +150,7 @@ void Matrix_Print(FILE *Dst, const char *Format, Matrix *Mat)
     p=*(Mat->p+i);
     for (j=0;j<NbColumns;j++) {
       if (!Format) {
-	value_print(Dst," "P_VALUE_FMT" ",*p++);
+	value_print(Dst," " P_VALUE_FMT " ",*p++);
       }
       else { 
 	value_print(Dst,Format,*p++);


### PR DESCRIPTION
Add spaces between string literals and P_VALUE_FMT in value_print calls so that the macro expansion concatenates properly. This avoids the invalid suffix warning under C++11 and ensures portable compilation.